### PR TITLE
Enable serving locally without building.

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -35,7 +35,12 @@ _configure_logging()
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main(dev_mode=False):
+  """ Runs the main server event loop.
+  Args:
+    dev_mode: If set to True, it will serve data from the base directory instead
+              of from the build directory. This is useful if we want to debug
+              stuff locally without running 'polymer build.'"""
   # Load the settings initially.
   try:
     settings_file = open("backend_settings.json")
@@ -47,12 +52,14 @@ def main():
   settings_file.close()
   logger.info("Loaded settings.")
 
-  bundled_path = "build/bundled"
-  bower_path = {"path": os.path.join(bundled_path, "bower_components")}
-  image_path = {"path": os.path.join(bundled_path, "images")}
-  template_path = settings.get("template_path", "build/bundled/src")
-  template_path = {"path": template_path}
-  root_path = {"path": os.path.join(bundled_path),
+  base_path = "build/bundled"
+  if dev_mode:
+    base_path = ""
+  bower_path = {"path": os.path.join(base_path, "bower_components")}
+  image_path = {"path": os.path.join(base_path, "images")}
+  template_path = settings.get("template_path", "src")
+  template_path = {"path": os.path.join(base_path, template_path)}
+  root_path = {"path": base_path,
                "default_filename": "index.html"}
 
   # Create and run the application.

--- a/backend_settings.json
+++ b/backend_settings.json
@@ -1,2 +1,2 @@
 {"listen_port": "8080",
- "template_path": "build/bundled/src/"}
+ "template_path": "src/"}

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "paper-styles": "PolymerElements/paper-styles#^1.1.5",
     "paper-listbox": "polymerelements/paper-listbox#^1.1.2",
     "paper-item": "PolymerElements/paper-item#^1.2.1",
-    "paper-progress": "PolymerElements/paper-progress#^1.0.11"
+    "paper-progress": "PolymerElements/paper-progress#^1.0.11",
+    "paper-dialog": "PolymerElements/paper-dialog#^1.1.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/deploy.py
+++ b/deploy.py
@@ -53,12 +53,12 @@ def run_all_tests():
 def main():
   parser = argparse.ArgumentParser( \
       description="Run and test the web application.")
-  parser.add_argument("-n", "--no_rebuild", action="store_true",
-                      help="Don't rebuild polymer app.")
+  parser.add_argument("-p", "--production", action="store_true",
+                      help="Rebuild polymer app and serve from build/bundled.")
   args = parser.parse_args()
 
   # Build the polymer app.
-  if not args.no_rebuild:
+  if args.production:
     print("Building polymer app...")
     build_polymer_app()
 
@@ -69,7 +69,7 @@ def main():
 
   # Run the dev server.
   print("Starting dev server...")
-  server.main()
+  server.main(dev_mode=(not args.production))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is really useful for doing quick local testing. Now, you
don't have to wait for polymer to rebuild in order to test the
app.