### PR TITLE
Module Discovery (PSoC)

### DIFF
--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/Export/PSoCCreatorExportIDE.xml
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/Export/PSoCCreatorExportIDE.xml
@@ -43,6 +43,7 @@
           <File BuildType="BUILD" Toolchain="">.\display.c</File>
           <File BuildType="BUILD" Toolchain="">.\water.c</File>
           <File BuildType="BUILD" Toolchain="">.\utils.c</File>
+          <File BuildType="BUILD" Toolchain="">.\discovery.c</File>
           <File BuildType="BUILD" Toolchain="">.\cyapicallbacks.h</File>
           <File BuildType="BUILD" Toolchain="">.\config.h</File>
           <File BuildType="BUILD" Toolchain="">.\messaging.h</File>
@@ -51,6 +52,7 @@
           <File BuildType="BUILD" Toolchain="">.\display.h</File>
           <File BuildType="BUILD" Toolchain="">.\water.h</File>
           <File BuildType="BUILD" Toolchain="">.\utils.h</File>
+          <File BuildType="BUILD" Toolchain="">.\discovery.h</File>
         </Files>
       </Folder>
       <Folder BuildType="STRICT" Path="C:\Users\pettid\git\grobot\psoc\grobot_workspace\grobot_module_controller.cydsn\Generated_Source\PSoC4">

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/discovery.c
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/discovery.c
@@ -1,0 +1,49 @@
+#include "discovery.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "config.h"
+#include "messaging.h"
+
+// We need to keep track of our controller ID. If this is the base system, it
+// will be 2, otherwise it will be determined during the discovery process.
+#ifdef IS_BASE_CONTROLLER
+static uint8_t g_controller_id = 2;
+#else
+static uint8_t g_controller_id = 3;
+#endif
+
+// Whether we have finished sending our discovery message.
+static bool g_imalive_sent = false;
+  
+void discovery_init() {
+#ifndef IS_BASE_CONTROLLER  
+  // Send the IMALIVE command to alert other modules that we are online.
+  messaging_send_message(0, "IMALIVE", "");
+  
+  // The way I2C works, after the above returns, the rest of the message must
+  // get sent, and no other masters can grab the bus in the meantime. That means
+  // that we're clear to start waiting for other IMALIVE messages at this point.
+  g_imalive_sent = true;
+#endif
+  
+  // Set the controller id.
+  messaging_set_controller_id(g_controller_id);
+}
+
+void discovery_handle_imalive() {
+#ifdef IS_BASE_CONTROLLER
+  // Don't do anything for the base controller.
+  return;
+#endif
+  
+  if (!g_imalive_sent) {
+    // Ignore them until we've sent our own.
+    return;
+  }
+  
+  // Increment the ID every time we receive one.
+  ++g_controller_id;
+  messaging_set_controller_id(g_controller_id);
+}

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/discovery.h
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/discovery.h
@@ -1,0 +1,14 @@
+#ifndef MODULE_CONTROLLER_DISCOVERY_H_
+#define MODULE_CONTROLLER_DISCOVERY_H_
+
+// Utilities related to module discovery. None of this will do much if it
+// is running on the base system controller.
+  
+// Begins the discovery process for this module. This should be run first
+// thing after the communications subsystems are initialized.
+void discovery_init();
+// Handles an IMALIVE message received from another module. This will
+// automatically set the module's ID as necessary.
+void discovery_handle_imalive();
+  
+#endif  // MODULE_CONTROLLER_DISCOVERY_H_

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/grobot_module_controller.cyprj
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/grobot_module_controller.cyprj
@@ -67,6 +67,13 @@
 <build_action v="C_FILE" />
 <PropertyDeltas />
 </CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
+<CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFile" version="3" xml_contents_version="1">
+<CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItem" version="2" name="discovery.c" persistent=".\discovery.c">
+<Hidden v="False" />
+</CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
+<build_action v="C_FILE" />
+<PropertyDeltas />
+</CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
 </dependencies>
 </CyGuid_0820c2e7-528d-4137-9a08-97257b946089>
 </CyGuid_2f73275c-45bf-46ba-b3b1-00a2fe0c8dd8>
@@ -135,6 +142,13 @@
 </CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
 <CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFile" version="3" xml_contents_version="1">
 <CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItem" version="2" name="utils.h" persistent=".\utils.h">
+<Hidden v="False" />
+</CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
+<build_action v="NONE" />
+<PropertyDeltas />
+</CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
+<CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFile" version="3" xml_contents_version="1">
+<CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItem" version="2" name="discovery.h" persistent=".\discovery.h">
 <Hidden v="False" />
 </CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
 <build_action v="NONE" />

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/lighting.c
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/lighting.c
@@ -78,6 +78,8 @@ void _send_led_status(uint8_t red_temp, uint8_t white_temp, uint8_t blue_temp,
            blue_temp, g_red_pwm, g_white_pwm, g_blue_pwm, fan_speed,
            g_temp_fault);
   
+  // Since this is just a status message, we don't have to block everything
+  // waiting for the send to succeed.
   messaging_send_message(1, "LEDSTS", fields);
 }
 

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/messaging.h
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/messaging.h
@@ -30,7 +30,7 @@ bool messaging_init(void (*message_handler)(struct Message message));
 //               and 2 is the base module controller.
 //  command: The command associated with the message.
 //  fields: The /-separated fields associated with the message.
-void messaging_send_message(uint8_t destination, const char *command,
+bool messaging_send_message(uint8_t destination, const char *command,
                             const char *fields);
 // Sends a message directly from a message structure.
 // WARNING: To save space, this function will directly overwrite parts of the
@@ -40,9 +40,8 @@ void messaging_send_message(uint8_t destination, const char *command,
 //  message: The message to send.
 void messaging_forward_message(struct Message *message);
 
-// Sets a new controller ID. It will only set it if it hasn't been set
-// before. Additionally, it will blink the new ID using the status LED for
-// debugging purposes.
+// Sets a new controller ID. Additionally, it will blink the new ID using
+// the status LED for debugging purposes.
 // Args:
 //  id: The new controller id.
 void messaging_set_controller_id(uint8_t id);

--- a/psoc/grobot_workspace/grobot_module_controller.cydsn/water.c
+++ b/psoc/grobot_workspace/grobot_module_controller.cydsn/water.c
@@ -111,6 +111,8 @@ void _send_water_status(uint8_t water_temp, int16_t water_ec,
   char fields[16];
   snprintf(fields, 16, "%u/%d/%u", water_temp, water_ec, water_ph);
   
+  // Since this is just a status message, we don't have to block everything
+  // waiting for the send to succeed.
   messaging_send_message(1, "WATSTS", fields);
 }
                         


### PR DESCRIPTION
Add module discovery code for the module MCUs.

Module discovery is the process that allows the system to correctly enumerate attached modules during startup and when a new one is added.

Please note that this remains untested on real-world hardware, since I don't have access to that right now.