### PR TITLE
Add support for permanent module IDs to the web interface.

### DIFF
--- a/backend/module.py
+++ b/backend/module.py
@@ -1,4 +1,5 @@
 import logging
+import random
 
 from .serial_talker import Message
 
@@ -9,13 +10,17 @@ logger = logging.getLogger(__name__)
 class Module:
   """ Represents a single module. """
 
-  def __init__(self, module_id):
+  def __init__(self, module_id, permanent_id):
     """
     Args:
-      module_id: The module's ID, which is also it's I2C slave address. """
+      module_id: The module's ID, which is also it's I2C slave address.
+      permanent_id: The module's permanent ID, which is stored in flash, and
+                    generally set only once during the module's lifetime. """
     self.__id = -1
+    self.__permanent_id = -1
 
     self.set_id(module_id)
+    self.set_permanent_id(permanent_id)
 
   def set_id(self, module_id):
     """ Sets a new ID for the module.
@@ -36,6 +41,34 @@ class Module:
     self.__id += 1
     logger.debug("Incrementing module ID to %d." % (self.__id))
 
+  def gen_permanent_id(self):
+    """ The permanent ID is different from the module ID used for communication
+    in that it is stored in the MCU flash and persistent accross resets. It is a
+    randomly-generated 32-bit number, and is used to uniquely identify modules
+    so that module-related information can be stored accross power cycles. This
+    method generates a new one. The generated permanent ID is automatically set
+    for this module.
+    Returns:
+      The generated permanent ID. """
+    permanent_id = random.getrandbits(32)
+    self.__permanent_id = permanent_id
+
+    return self.__permanent_id
+
+  def set_permanent_id(self, permanent_id):
+    """ Sets the permanent ID for this module.
+    Args:
+      permanent_id: The new permanent ID. """
+    logger.debug("Changing permanent ID from %d to %d." % (self.__permanent_id,
+                                                           permanent_id))
+    self.__permanent_id = permanent_id
+
+  def get_permanent_id(self):
+    """
+    Returns:
+      The currently set permanent ID. """
+    return self.__permanent_id
+
 
 class ModuleInterface:
   """ Handles global tasks pertaining to the entire set of modules. """
@@ -53,26 +86,44 @@ class ModuleInterface:
     self.__serial = serial
 
     # Initialize the serial handler.
-    self.__serial.add_message_handler(self.__imalive_handler)
+    self.__serial.add_message_handler(self.__common_handler)
 
-  def __imalive_handler(self, message):
-    """ Handles incoming IMALIVE messages. It essentially runs the same
-    algorithm that the modules themselves run upon seeing this message, to
-    ensure that the IDs it sets for them here match the ones they choose for
-    themselves.
+  def __get_module_by_id(self, module_id):
+    """ Gets a particular module by its ID.
     Args:
-      message: The received message. """
-    if message.command == Message.ImAlive:
-      # Add the new module.
-      self.add_module()
+      module_id: The ID of the module.
+    Returns:
+      The module with that ID. """
+    for module in self.__modules:
+      if module.get_id() == module_id:
+        return module
 
-  def add_module(self):
-    """ Adds a new module to the system. """
+    # This has got to be a programming error.
+    raise KeyError("No module with ID %d." % (module_id))
+
+  def __common_handler(self, message):
+    """ Handles all relevant messages coming from the modules.
+    Args:
+      message: The message to handle. """
+
+    if message.command == Message.ImAlive:
+      # Handles incoming IMALIVE messages. It essentially runs the same
+      # algorithm that the modules themselves run upon seeing this message, to
+      # ensure that the IDs it sets for them here match the ones they choose for
+      # themselves. The first field of this message is the module's currently
+      # set permanent ID.
+      self.add_module(int(message.fields[0]))
+
+  def add_module(self, permanent_id):
+    """ Adds a new module to the system. The module's permanent ID will also be
+    automatically generated if it does not already exist.
+    Args:
+      permanent_id: The permanent ID of the module. """
     logger.info("Discovered new module.")
 
     # The newest module always gets assigned the lowest ID, which is 3 in this
     # case since 0 is broadcast, 1 is us, and 2 is the BSC.
-    new_module = Module(3)
+    new_module = Module(3, permanent_id)
 
     # Increment all the other module IDs, since this is what they will do upon
     # receipt of the message.
@@ -81,6 +132,24 @@ class ModuleInterface:
 
     # Save the module.
     self.__modules.add(new_module)
+
+    if not permanent_id:
+      # We need to generate a permanent ID for this module.
+      self.gen_permanent_id(new_module.get_id())
+
+  def gen_permanent_id(self, module_id):
+    """ Generates a new permanent ID for a module, and sends it to that module.
+    Args:
+      module_id: The (I2C) ID of the module. """
+    module = self.__get_module_by_id(module_id)
+
+    # Generate one.
+    permanent_id = module.gen_permanent_id()
+    logger.debug("Generated permanent ID for module %d: %d" % (module_id,
+                                                               permanent_id))
+
+    # Set it on the MCU.
+    self.__serial.write_command(Message.SetPermanentId, module_id, permanent_id)
 
   def get_modules(self):
     """

--- a/backend/module.py
+++ b/backend/module.py
@@ -156,3 +156,7 @@ class ModuleInterface:
     Returns:
       The set of modules currently attached. """
     return self.__modules
+
+  def clear_modules(self):
+    """ Clears all the currently managed modules. """
+    self.__modules.clear()

--- a/backend/module_sim/grow_module.py
+++ b/backend/module_sim/grow_module.py
@@ -11,18 +11,24 @@ logger = logging.getLogger(__name__)
 class GrowModule(module_common.ModuleCommon):
   """ Simulates a grow module controller. """
 
-  def __init__(self, *args, **kwargs):
+  def __init__(self, *args, permanent_id=0, **kwargs):
+    """
+    Args:
+      permanent_id: Allows the user to specify a permanend ID for this module.
+                    None is specified, it will act as if the permanent ID is not
+                    set. """
     super().__init__(*args, **kwargs)
 
     # The ID of a Grow Module defaults to 3.
     self._id = 3
+    self.__permanent_id = permanent_id
     # Whether we've written our discovery message yet.
     self.__sent_imalive = False
 
   def on_startup(self):
     """ See superclass documentation. """
     # Send the initial discovery message.
-    self._write_message(serial_talker.Message.ImAlive, 0)
+    self._write_message(serial_talker.Message.ImAlive, 0, self.__permanent_id)
     self.__sent_imalive = True
 
   def _handle_message(self, message):

--- a/backend/module_sim/grow_module.py
+++ b/backend/module_sim/grow_module.py
@@ -25,18 +25,49 @@ class GrowModule(module_common.ModuleCommon):
     # Whether we've written our discovery message yet.
     self.__sent_imalive = False
 
-  def on_startup(self):
-    """ See superclass documentation. """
-    # Send the initial discovery message.
-    self._write_message(serial_talker.Message.ImAlive, 0, self.__permanent_id)
-    self.__sent_imalive = True
+  def __handle_imalive(self, message):
+    """ Handles ImAlive messages.
+    Args:
+      message: The message to handle. """
+    if self.__sent_imalive:
+      # Increment the ID when we see a new "module".
+      self._id += 1
+      logger.debug("Incrementing ID to %d" % (self._id))
+
+  def __handle_setpermanentid(self, message):
+    """ Handles SetPermanentId messages.
+    Args:
+      message: The message to handle. """
+    # Reset the permanent ID.
+    permanent_id = int(message.fields[0])
+    logger.debug("Module %d: Setting permanent ID to %d." % \
+                 (self._id, permanent_id))
+
+    self.__permanent_id = permanent_id
+
+  def __handle_getpermanentid(self, message):
+    """ Handles GetPermanentId messages.
+    Args:
+      message: The message to handle. """
+    # Send the permanent ID to the requester.
+    logger.debug("%d: Permanent ID request from %d." % (self._id,
+                                                        message.source))
+    self._write_message(serial_talker.Message.GetPermanentId, message.source,
+                        self.__permanent_id)
 
   def _handle_message(self, message):
     """ See superclass documentation. """
     super()._handle_message(message)
 
     if message.command == serial_talker.Message.ImAlive:
-      if self.__sent_imalive:
-        # Increment the ID when we see a new "module".
-        self._id += 1
-        logger.debug("Incrementing ID to %d" % (self._id))
+      self.__handle_imalive(message)
+    if message.command == serial_talker.Message.SetPermanentId:
+      self.__handle_setpermanentid(message)
+    if message.command == serial_talker.Message.GetPermanentId:
+      self.__handle_getpermanentid(message)
+
+  def on_startup(self):
+    """ See superclass documentation. """
+    # Send the initial discovery message.
+    self._write_message(serial_talker.Message.ImAlive, 0, self.__permanent_id)
+    self.__sent_imalive = True

--- a/backend/module_sim/simulator.py
+++ b/backend/module_sim/simulator.py
@@ -133,3 +133,8 @@ class Simulator:
     # Fork off a separate process that does the simulation.
     self.__sim_process = Process(target=self.__run)
     self.__sim_process.start()
+
+  def clear_modules(self):
+    """ Removes all currently added modules. """
+    self.__modules.clear()
+    logger.info("Cleared simulated modules.")

--- a/backend/serial_talker.py
+++ b/backend/serial_talker.py
@@ -139,7 +139,9 @@ class Message:
   Ping = "PING"
   # An IMALIVE command is the first thing sent out by modules when
   # they finish initializing. It is used in the module discovery
-  # process.
+  # process. This message should always have one argument, which is the
+  # permanent ID of the module sending it. That can also be 0 if the module
+  # does not have a permanent ID set.
   ImAlive = "IMALIVE"
   # A SetLedBrightness command does pretty much what the name implies.
   SetLedBrightness = "SETLED"
@@ -153,6 +155,8 @@ class Message:
   # should be send regularly from the MCU. Prime can disable these if it is not
   # in a position to handle them.
   SendSensorStatus = "ENSTAT"
+  # Sets the permanent ID of a module.
+  SetPermanentId = "SETPERMID"
 
   def __init__(self, *args, source=1):
     """ Checks the number of arguments, and defers to the proper method for
@@ -313,7 +317,7 @@ class SerialTalker:
   def write_command(self, *args, **kwargs):
     """ This is really just a convenience method for building a message and
     sending it to the MCU. All arguments are passed transparently to a
-    Message intstance. It is asynchronous, and will return before the data is
+    Message instance. It is asynchronous, and will return before the data is
     fully sent. """
     message = Message(*args, **kwargs)
     self.write_existing_message(message)

--- a/backend/serial_talker.py
+++ b/backend/serial_talker.py
@@ -157,6 +157,11 @@ class Message:
   SendSensorStatus = "ENSTAT"
   # Sets the permanent ID of a module.
   SetPermanentId = "SETPERMID"
+  # Gets the permanent ID of a module. The response to this command will be a
+  # command of the same type with the ID as one of the fields. Since ImAlive
+  # also sends the permanent ID, this is used mostly for testing and debugging
+  # and not for normal system operation.
+  GetPermanentId = "GETPERMID"
 
   def __init__(self, *args, source=1):
     """ Checks the number of arguments, and defers to the proper method for

--- a/backend/tests/test_module.py
+++ b/backend/tests/test_module.py
@@ -1,0 +1,115 @@
+import logging
+import random
+
+from .. import module
+from ..serial_talker import Message
+
+from . import base_test
+from . import test_module_sim
+
+""" Tests the module management code. """
+
+
+logger = logging.getLogger(__name__)
+
+
+class ModuleTest(base_test.BaseTest):
+  """ Tests for the Module class. """
+
+  def setUp(self):
+    super().setUp()
+
+    # Make a module for testing.
+    self.__module = module.Module(-1, -1)
+
+  def test_increment(self):
+    """ Tests that the ID incrementing functionality works. """
+    self.__module.set_id(1)
+    self.assertEqual(1, self.__module.get_id())
+
+    self.__module.increment_id()
+    self.assertEqual(2, self.__module.get_id())
+
+  def test_permanent_id(self):
+    """ Tests that the permanent ID functionality works. """
+    self.__module.set_permanent_id(42)
+    self.assertEqual(42, self.__module.get_permanent_id())
+
+    # Try generating a new one.
+    random.seed(10)
+    expected = random.getrandbits(32)
+
+    random.seed(10)
+    self.assertEqual(expected, self.__module.gen_permanent_id())
+    self.assertEqual(expected, self.__module.get_permanent_id())
+
+class ModuleInterfaceTest(test_module_sim.SimulatorTestBase):
+  """ Tests for the ModuleInterface class. """
+
+  def setUp(self):
+    super().setUp()
+
+    # Make a module interface using the serial connection from the simulated
+    # modules.
+    self.__stack = module.ModuleInterface(self._serial)
+
+  def test_discovery(self):
+    """ Make sure module discovery works properly. """
+    # Start the module simulation. It should immediately begin discovery.
+    self._start_simulator(3)
+
+    # Wait for the three discovery messages so we know the process is complete.
+    # (The zero field is because the permanent ID will not be set by default.)
+    disc_expected = Message(Message.ImAlive, 0, "0", source=3)
+    self._wait_for_message(disc_expected, expect_number=3)
+
+    # Now make sure the module interface handled this correctly.
+    modules = self.__stack.get_modules()
+    self.assertEqual(3, len(modules))
+
+    # Make sure the IDs are set correctly.
+    available_ids = set([3, 4, 5])
+    for module in modules:
+      self.assertIn(module.get_id(), available_ids)
+      available_ids.remove(module.get_id())
+
+  def test_permanent_id(self):
+    """ Make sure that module permanent IDs work. """
+    # Start the module simulation.
+    self._start_simulator(1)
+
+    # Seed the RNG so we can control what ID it picks.
+    random.seed(10)
+    expected_id = random.getrandbits(32)
+    random.seed(10)
+
+    # Wait for the discovery message. The permanent ID should not be set.
+    disc_expected = Message(Message.ImAlive, 0, "0", source=3)
+    self._wait_for_message(disc_expected)
+
+    # Make sure the module interface handled this correctly.
+    modules = self.__stack.get_modules()
+    self.assertEqual(1, len(modules))
+
+    for module in modules:
+      # It should pick a new, "random" ID.
+      self.assertEqual(expected_id, module.get_permanent_id())
+
+    # The simulated module should also reflect this change.
+    perm_id_prompt = Message(Message.GetPermanentId, 3)
+    perm_id_expected = Message(Message.GetPermanentId, 1, str(expected_id),
+                               source=3)
+    self._wait_for_message(perm_id_expected, prompt=perm_id_prompt)
+
+    # Reset the simulation. This time, specify a permanent ID.
+    self._reset_simulator()
+    self.__stack.clear_modules()
+    self._start_simulator(1, permanent_id=42)
+
+    disc_expected = Message(Message.ImAlive, 0, "42", source=3)
+    self._wait_for_message(disc_expected)
+
+    # Make sure the module interface reflects this.
+    modules = self.__stack.get_modules()
+    for module in modules:
+      self.assertEqual(42, module.get_permanent_id())

--- a/backend/tests/test_module_sim.py
+++ b/backend/tests/test_module_sim.py
@@ -90,8 +90,9 @@ class TestSimulator(SimulatorTestBase):
     """ Tests that we can handle a ping command on the grow module. """
     self._start_simulator(1)
 
-    # We first expect to receive a discovery message.
-    expected = serial_talker.Message(serial_talker.Message.ImAlive, 0,
+    # We first expect to receive a discovery message. The zero field is because
+    # the permanent ID defaults to zero.
+    expected = serial_talker.Message(serial_talker.Message.ImAlive, 0, "0",
                                      source=3)
     self._wait_for_message(expected)
 
@@ -123,7 +124,7 @@ class TestSimulator(SimulatorTestBase):
     # We expect to receive 3 discovery messages. (All the modules will have
     # their IDs set to 3 initially, so it will look like they are coming from
     # the same source.)
-    disc_expected = serial_talker.Message(serial_talker.Message.ImAlive, 0,
+    disc_expected = serial_talker.Message(serial_talker.Message.ImAlive, 0, "0",
                                           source=3)
     # Wait for all three of them, in an arbitrary order.
     self._wait_for_message(disc_expected, expect_number=3)


### PR DESCRIPTION
A permanent module ID is an ID that is stored in flash on the MCU. It is not used for communication, but rather so the web interface can keep track of module settings.