### PR TITLE
Fix outdated state element in modal handler.

### DIFF
--- a/src/js/gb-error-modal.js
+++ b/src/js/gb-error-modal.js
@@ -12,7 +12,7 @@ gbErrorModal.create = function() {
         type: Boolean,
         value: false,
         observer: 'allGoodChanged_',
-        statePath: 'fromBackend.mcuAlive',
+        statePath: 'fromBackend.mcu_alive',
       }
     },
 


### PR DESCRIPTION
This was causing it to show the error modal when it wasn't
supposed to.