### PR TITLE
Temporary fix for WCT hanging issue.

### DIFF
--- a/containers/testing/Dockerfile
+++ b/containers/testing/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN apt-get install -y nodejs
 
 # Install node packages.
-RUN /usr/bin/npm install -g bower polymer-cli redux web-component-tester
+RUN /usr/bin/npm install -g bower polymer-cli redux web-component-tester@6.3.0
 
 # Install everything in bower.json.
 ADD bower.json .

--- a/test_ci.sh
+++ b/test_ci.sh
@@ -3,4 +3,4 @@
 # Builds and runs tests inside a container for CI.
 
 docker build -t grobot-testing -f containers/testing/Dockerfile .
-docker run -v `pwd`:/grobot -w /grobot grobot-testing ./deploy.py -tc
+docker run -v `pwd`:/grobot -v /dev/shm:/dev/shm -w /grobot grobot-testing ./deploy.py -tc


### PR DESCRIPTION
I reverted back to 6.3.0 for now.

This was what was causing CI builds to time out recently.

See the issue I submitted here:
https://github.com/Polymer/web-component-tester/issues/648